### PR TITLE
Fix double free in OGRTABDataSource::Create() when exiting with error (h...

### DIFF
--- a/mitab/mitab_miffile.cpp
+++ b/mitab/mitab_miffile.cpp
@@ -326,7 +326,6 @@ int MIFFile::Open(const char *pszFname, const char *pszAccess,
         else
             CPLErrorReset();
 
-        CPLFree(m_pszFname);
         return -1;
     }
 


### PR DESCRIPTION
...ttp://trac.osgeo.org/gdal/ticket/4730)
